### PR TITLE
[#16] Add TZIP-16 metadata and views

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -6,7 +6,8 @@
 # Settings
 ###########################################################################
 
-- arguments: [-XTypeApplications, -XRecursiveDo, -XBlockArguments]
+- arguments: [-XTemplateHaskell, -XQuasiQuotes, -XTypeApplications,
+    -XRecursiveDo, -XBlockArguments]
 
 # These are just too annoying
 - ignore: { name: Redundant do }

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ actually implemented, can instead be obtained by from [the latest
 release](https://github.com/tezos-commons/homebase-lite/releases/latest)
 or produced with [the `homebase-lite` tool](docs/tool.md#getting-the-contract-documentation).
 
+### [TZIP-16](https://tzip.tezosagora.org/proposal/tzip-16/) off-chain views
+
+The contract declares TZIP-16 metadata in its storage, which includes two off-chain views:
+
+- `currentConfig`: accepts no parameters and returns the [`Configuration`](https://github.com/tezos-commons/homebase-lite/blob/autodoc/master/documentation.md#types-Configuration) object containing the current configuration of the contract (as defined in the spec).
+- `proposalInfo`: accepts a proposal [`URI`](https://github.com/tezos-commons/homebase-lite/blob/autodoc/master/documentation.md#types-URI) (as `string`) and returns a [`ProposalInfo`](https://github.com/tezos-commons/homebase-lite/blob/autodoc/master/documentation.md#types-ProposalInfo) object for the proposal identified by the `URI`, or throws a [`NoSuchProposal`](https://github.com/tezos-commons/homebase-lite/blob/autodoc/master/documentation.md#errors-NoSuchProposal) error if no such proposal exists.
+
 ## The `homebase-lite` tool
 
 This repository includes a [`homebase-lite` utility tool](docs/tool.md), which

--- a/docs/tool.md
+++ b/docs/tool.md
@@ -108,4 +108,4 @@ Please also note that there is no way to change the fa2 contract address after t
 
 Upon successful origination, the contract's address is printed to stdout and stored in `tezos-client`'s alias store with the alias `homebase-lite`. Note that if the alias already exists it will be overwritten. You can specify a different alias with the `--name` option.
 
-You can also specify FA2 token id and any other initial storage parameters. See `homebase-lite originate --help` for more information.
+You can also specify FA2 token id and other initial storage parameters. See `homebase-lite originate --help` for more information.

--- a/homebase-lite.cabal
+++ b/homebase-lite.cabal
@@ -25,6 +25,10 @@ library
       Indigo.Contracts.HomebaseLite
       Indigo.Contracts.HomebaseLite.Impl
       Indigo.Contracts.HomebaseLite.Impl.Admin
+      Indigo.Contracts.HomebaseLite.Impl.Contract
+      Indigo.Contracts.HomebaseLite.Impl.Metadata
+      Indigo.Contracts.HomebaseLite.Impl.Metadata.Views
+      Indigo.Contracts.HomebaseLite.Impl.Storage
       Indigo.Contracts.HomebaseLite.Impl.Utils
       Indigo.Contracts.HomebaseLite.Impl.Vote
       Indigo.Contracts.HomebaseLite.Optimizer
@@ -83,11 +87,15 @@ library
       ViewPatterns
   ghc-options: -Weverything -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-safe -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-implicit-prelude -Wno-unused-packages
   build-depends:
-      base-noprelude >=4.7 && <5
+      aeson
+    , base-noprelude >=4.7 && <5
+    , bytestring
     , data-default
     , indigo
+    , lorentz
     , morley
     , morley-ledgers
+    , morley-metadata
     , morley-prelude
     , template-haskell
     , text
@@ -172,6 +180,8 @@ test-suite homebase-lite-test
   other-modules:
       Test.Indigo.Contracts.HomebaseLite.Admin.Entrypoints
       Test.Indigo.Contracts.HomebaseLite.AsRPC
+      Test.Indigo.Contracts.HomebaseLite.Metadata.Data
+      Test.Indigo.Contracts.HomebaseLite.Metadata.Views
       Test.Indigo.Contracts.HomebaseLite.PropertyTests
       Test.Indigo.Contracts.HomebaseLite.Utils
       Test.Indigo.Contracts.HomebaseLite.Vote.Entrypoints
@@ -239,10 +249,13 @@ test-suite homebase-lite-test
     , lorentz
     , morley
     , morley-ledgers
+    , morley-metadata
+    , morley-metadata-test
     , morley-prelude
     , o-clock
     , tasty
     , tasty-hedgehog
+    , text
   if impl(ghc >= 8.10.0)
     ghc-options: -Wno-prepositive-qualified-module -Wno-inferred-safe-imports -Wno-missing-safe-haskell-mode
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -91,10 +91,14 @@ dependencies:
 library:
   source-dirs: src
   dependencies:
+    - aeson
+    - bytestring
     - data-default
     - indigo
+    - lorentz
     - morley
     - morley-ledgers
+    - morley-metadata
     - morley-prelude
     - template-haskell
     - text
@@ -137,6 +141,9 @@ tests:
     - lorentz
     - morley
     - morley-ledgers
+    - morley-metadata
+    - morley-metadata-test
     - o-clock
     - tasty
     - tasty-hedgehog
+    - text

--- a/src/Indigo/Contracts/HomebaseLite.hs
+++ b/src/Indigo/Contracts/HomebaseLite.hs
@@ -4,15 +4,9 @@
 module Indigo.Contracts.HomebaseLite
   ( Parameter(..)
   , Storage(..)
-  , homebaseLiteCode
+  , lorentzContract
   , initialStorage
   ) where
 
-import Indigo (ContractCode, compileIndigoContract)
-
 import Indigo.Contracts.HomebaseLite.Impl
-import Indigo.Contracts.HomebaseLite.Optimizer
 import Indigo.Contracts.HomebaseLite.Types
-
-homebaseLiteCode :: ContractCode Parameter Storage
-homebaseLiteCode = optimize $ compileIndigoContract homebaseLiteContract

--- a/src/Indigo/Contracts/HomebaseLite/Impl.hs
+++ b/src/Indigo/Contracts/HomebaseLite/Impl.hs
@@ -2,62 +2,9 @@
 -- SPDX-License-Identifier: LicenseRef-MIT-TC
 
 module Indigo.Contracts.HomebaseLite.Impl
-  ( homebaseLiteContract
+  ( lorentzContract
   , initialStorage
   ) where
 
-import Indigo hiding ((*))
-
-import Morley.Util.Interpolate (itu)
-import Morley.Util.Named
-
-import Indigo.Contracts.HomebaseLite.Impl.Admin
-import Indigo.Contracts.HomebaseLite.Impl.Vote
-import Indigo.Contracts.HomebaseLite.Types
-
-initialStorage
-  :: ("admin" :! Address)
-  -> ("expireTime" :! Seconds)
-  -> ("voteDelay" :! Seconds)
-  -> ("quorumThreshold" :! Natural)
-  -> ("minimumBalance" :! Natural)
-  -> ("fa2config" :! FA2Config)
-  -> Storage
-initialStorage (N admin) (N expireTime) (N voteDelay) (N quorumThreshold) (N minimumBalance)
-  (N fa2config)
-  = Storage
-    { sAdmin = admin
-    , sAdminCandidate = admin
-    , sMaintainers = def
-    , sConfiguration = Configuration
-      { cExpireTime = expireTime
-      , cVoteDelay = voteDelay
-      , cQuorumThreshold = quorumThreshold
-      , cMinimumBalance = minimumBalance
-      }
-    , sFA2Config = fa2config
-    , sProposals = def
-    , sVotes = def
-    }
-
-homebaseLiteContract :: IndigoContract Parameter Storage
-homebaseLiteContract param = defContract $ docGroup "Homebase Lite" do
-  contractGeneralDefault
-  description [itu|
-    Homebase Lite is an offchain, decentralized voting system. It aims to
-    provide a very simple interface for communities to propose and vote on
-    decisions that do not require binding actions, e.g. to request feedback,
-    run polls, etc.
-
-    It aims to be a very lightweight complement to Homebase.|]
-  doc $ dStorage @Storage
-  entryCaseSimple param
-    ( #cSet_admin #= setAdmin
-    , #cAccept_admin #= acceptAdmin
-    , #cAdd_maintainers #= addMaintainers
-    , #cRemove_maintainers #= removeMaintainers
-    , #cConfigure #= configure
-    , #cPropose #= propose
-    , #cVote #= vote
-    , #cVerify_min_balance #= verifyMinBalance
-    )
+import Indigo.Contracts.HomebaseLite.Impl.Contract
+import Indigo.Contracts.HomebaseLite.Impl.Storage

--- a/src/Indigo/Contracts/HomebaseLite/Impl/Contract.hs
+++ b/src/Indigo/Contracts/HomebaseLite/Impl/Contract.hs
@@ -1,0 +1,44 @@
+-- SPDX-FileCopyrightText: 2022 Tezos Commons
+-- SPDX-License-Identifier: LicenseRef-MIT-TC
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE RebindableSyntax #-}
+
+module Indigo.Contracts.HomebaseLite.Impl.Contract
+  ( lorentzContract
+  ) where
+
+import Indigo hiding ((*))
+import qualified Lorentz as L
+
+import Morley.Util.Interpolate (itu)
+
+import Indigo.Contracts.HomebaseLite.Impl.Admin
+import Indigo.Contracts.HomebaseLite.Impl.Vote
+import Indigo.Contracts.HomebaseLite.Optimizer
+import Indigo.Contracts.HomebaseLite.Types
+
+indigoContract :: IndigoContract Parameter Storage
+indigoContract param = defContract $ docGroup "Homebase Lite" do
+  contractGeneralDefault
+  description [itu|
+    Homebase Lite is an offchain, decentralized voting system. It aims to
+    provide a very simple interface for communities to propose and vote on
+    decisions that do not require binding actions, e.g. to request feedback,
+    run polls, etc.
+
+    It aims to be a very lightweight complement to Homebase.|]
+  doc $ dStorage @Storage
+  entryCaseSimple param
+    ( #cSet_admin #= setAdmin
+    , #cAccept_admin #= acceptAdmin
+    , #cAdd_maintainers #= addMaintainers
+    , #cRemove_maintainers #= removeMaintainers
+    , #cConfigure #= configure
+    , #cPropose #= propose
+    , #cVote #= vote
+    , #cVerify_min_balance #= verifyMinBalance
+    )
+
+lorentzContract :: L.Contract Parameter Storage ()
+lorentzContract = defaultContract $ optimize $ compileIndigoContract indigoContract

--- a/src/Indigo/Contracts/HomebaseLite/Impl/Metadata.hs
+++ b/src/Indigo/Contracts/HomebaseLite/Impl/Metadata.hs
@@ -1,0 +1,86 @@
+-- SPDX-FileCopyrightText: 2022 Tezos Commons
+-- SPDX-License-Identifier: LicenseRef-MIT-TC
+
+{-# LANGUAGE OverloadedLists #-}
+
+module Indigo.Contracts.HomebaseLite.Impl.Metadata
+  ( metadataBigMap
+  , versionString
+  , gitRev
+  ) where
+
+import Indigo hiding (cast, description, name, (<>))
+import qualified Lorentz as L
+
+import Data.Aeson (encode)
+import qualified Data.ByteString.Lazy as BS
+import Data.Text.Internal.Builder (toLazyText)
+import Data.Typeable (cast)
+
+import qualified Lorentz.Contracts.Spec.TZIP16Interface as TZ16
+import Morley.Metadata (compileViewCodeTH, mkSimpleMichelsonStorageView)
+import Morley.Micheline (toExpression)
+import Morley.Michelson.Text (unsafeMkMText)
+import Morley.Util.Markdown (HeaderLevel(..))
+
+import Indigo.Contracts.HomebaseLite.Impl.Contract
+import Indigo.Contracts.HomebaseLite.Impl.Metadata.Views
+import Indigo.Contracts.HomebaseLite.Types
+
+metadataBigMap :: MetadataConfig -> TZ16.MetadataMap BigMap
+metadataBigMap conf = TZ16.metadataURI (TZ16.tezosStorageUri TZ16.selfHost metadataKey)
+  <> [(metadataKey, BS.toStrict $ encode $ metadataJSON conf)]
+  where metadataKey = [mt|metadata|]
+
+metadataJSON :: MetadataConfig -> TZ16.Metadata (ToT Storage)
+metadataJSON MetadataConfig{..} = mconcat
+  [ TZ16.name mcName
+  , TZ16.description mcDescription
+  , TZ16.authors [ TZ16.author "Serokell" "https://serokell.io"
+                 , TZ16.author "Tezos Commons" "https://tezoscommons.org/" ]
+  , TZ16.version versionString
+  , TZ16.license $ TZ16.License "MIT" Nothing
+  , TZ16.homepage "https://github.com/tezos-commons/homebase-lite"
+  , TZ16.errors collectContractErrors
+  , TZ16.views
+      [ currentConfigView
+      , proposalInfoView
+      ]
+  , TZ16.interfaces [TZ16.tzip 16]
+  ]
+
+collectContractErrors :: [TZ16.Error]
+collectContractErrors =
+  let d = L.buildDoc $ L.finalizedAsIs lorentzContract
+  in catMaybes $ toList (cdDefinitionsSet d) <&> \(SomeDocDefinitionItem item) ->
+    (cast item :: Maybe DError) <&> \(DError (Proxy :: Proxy e)) ->
+      TZ16.EStatic TZ16.StaticError
+        { seError = toExpression . toVal . unsafeMkMText $ errorDocName @e
+        , seExpansion = toExpression
+          . toVal . unsafeMkMText . toText . toLazyText $ errorDocMdCause @e
+        , seLanguages = ["en-US"]
+        }
+
+currentConfigView :: TZ16.View (ToT Storage)
+currentConfigView = TZ16.View
+  { vName = "currentConfig"
+  , vDescription = Nothing
+  , vPure = Nothing
+  , vImplementations = one $ TZ16.VIMichelsonStorageView $
+      mkSimpleMichelsonStorageView $ $$(compileViewCodeTH currentConfigCode)
+  }
+
+proposalInfoView :: TZ16.View (ToT Storage)
+proposalInfoView = TZ16.View
+  { vName = "proposalInfo"
+  , vDescription = Nothing
+  , vPure = Nothing
+  , vImplementations = one $ TZ16.VIMichelsonStorageView $
+      mkSimpleMichelsonStorageView $ $$(compileViewCodeTH proposalInfoCode)
+  }
+
+versionString :: Text
+versionString = toText $ toLazyText $ docItemToMarkdown (HeaderLevel 0) gitRev
+
+gitRev :: DGitRevision
+gitRev = $mkDGitRevision $ GitRepoSettings ("https://github.com/tezos-commons/homebase-lite/commit/" <>)

--- a/src/Indigo/Contracts/HomebaseLite/Impl/Metadata/Views.hs
+++ b/src/Indigo/Contracts/HomebaseLite/Impl/Metadata/Views.hs
@@ -1,0 +1,27 @@
+-- SPDX-FileCopyrightText: 2022 Tezos Commons
+-- SPDX-License-Identifier: LicenseRef-MIT-TC
+
+{-# OPTIONS_GHC -Wno-unused-do-bind #-}
+{-# LANGUAGE RebindableSyntax #-}
+
+module Indigo.Contracts.HomebaseLite.Impl.Metadata.Views
+  ( currentConfigCode
+  , proposalInfoCode
+  ) where
+
+import Lorentz hiding (ViewCode)
+
+import Morley.Metadata (ViewCode(..))
+
+import Indigo.Contracts.HomebaseLite.Impl.Vote ()
+import Indigo.Contracts.HomebaseLite.Optimizer
+import Indigo.Contracts.HomebaseLite.Types
+
+currentConfigCode :: ViewCode Storage Configuration
+currentConfigCode = WithoutParam $ optimize $ toField #sConfiguration
+
+proposalInfoCode :: ViewCode Storage ProposalInfo
+proposalInfoCode = WithParam @("proposal_uri" :! URI) $ optimize do
+  dip (toField #sProposals)
+  get
+  ifSome nop $ failCustomNoArg #noSuchProposal

--- a/src/Indigo/Contracts/HomebaseLite/Impl/Storage.hs
+++ b/src/Indigo/Contracts/HomebaseLite/Impl/Storage.hs
@@ -1,0 +1,43 @@
+-- SPDX-FileCopyrightText: 2022 Tezos Commons
+-- SPDX-License-Identifier: LicenseRef-MIT-TC
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE RebindableSyntax #-}
+
+module Indigo.Contracts.HomebaseLite.Impl.Storage
+  ( initialStorage
+  ) where
+
+import Indigo hiding ((*))
+
+import Morley.Util.Named (pattern N)
+
+import Indigo.Contracts.HomebaseLite.Impl.Metadata
+import Indigo.Contracts.HomebaseLite.Types
+
+initialStorage
+  :: ("admin" :! Address)
+  -> ("expireTime" :! Seconds)
+  -> ("voteDelay" :! Seconds)
+  -> ("quorumThreshold" :! Natural)
+  -> ("minimumBalance" :! Natural)
+  -> ("fa2config" :! FA2Config)
+  -> ("metadataConfig" :! MetadataConfig)
+  -> Storage
+initialStorage (N admin) (N expireTime) (N voteDelay) (N quorumThreshold) (N minimumBalance)
+  (N fa2config) (N contractMetadataConfig)
+  = Storage
+    { sAdmin = admin
+    , sAdminCandidate = admin
+    , sMaintainers = def
+    , sConfiguration = Configuration
+      { cExpireTime = expireTime
+      , cVoteDelay = voteDelay
+      , cQuorumThreshold = quorumThreshold
+      , cMinimumBalance = minimumBalance
+      }
+    , sFA2Config = fa2config
+    , sProposals = def
+    , sVotes = def
+    , sMetadata = metadataBigMap contractMetadataConfig
+    }

--- a/src/Indigo/Contracts/HomebaseLite/Optimizer.hs
+++ b/src/Indigo/Contracts/HomebaseLite/Optimizer.hs
@@ -5,7 +5,7 @@ module Indigo.Contracts.HomebaseLite.Optimizer
     ( optimize
     ) where
 
-import Indigo (ContractCode, optimizeLorentzWithConf)
+import Indigo (optimizeLorentzWithConf, (:->))
 
 import Data.Default (def)
 import Data.Type.Equality ((:~:)(Refl))
@@ -17,7 +17,7 @@ import Morley.Util.Peano (Decrement, Drop, IsLongerOrSameLength, IsLongerThan, N
 import Morley.Util.PeanoNatural (PeanoNatural(..), fromPeanoNatural)
 import Morley.Util.Type (type (++))
 
-optimize :: ContractCode ps st -> ContractCode ps st
+optimize :: inp :-> out -> inp :-> out
 optimize = optimizeLorentzWithConf optimizerConf
 
 -- | Turn rule fixpoint into rule.

--- a/stack.yaml
+++ b/stack.yaml
@@ -31,6 +31,15 @@ extra-deps:
     - code/morley-ledgers
     - code/morley-ledgers-test
 
+- git:
+    https://gitlab.com/morley-framework/morley-metadata.git
+    # ^ CI cannot use ssh, so we use http clone here
+  commit:
+    5a54cc98931327f6f110e3a34f6f23176c064396 # master
+  subdirs:
+    - code/morley-metadata
+    - code/morley-metadata-test
+
 # Required by morley
 - git: https://github.com/serokell/base-noprelude.git
   commit: 1282e0b992b00089d55228a2aa9edc4a3581c319

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -79,6 +79,32 @@ packages:
     git: https://gitlab.com/morley-framework/morley-ledgers.git
     commit: 3a7d14cff8ea011e79ceec0bcdc1668bf987f7e9
 - completed:
+    subdir: code/morley-metadata
+    name: morley-metadata
+    version: '0'
+    git: https://gitlab.com/morley-framework/morley-metadata.git
+    pantry-tree:
+      size: 1216
+      sha256: 984687f727970755f87df34cc6fce0ee4fa3a5d60b091373feec4b164c8a0648
+    commit: 5a54cc98931327f6f110e3a34f6f23176c064396
+  original:
+    subdir: code/morley-metadata
+    git: https://gitlab.com/morley-framework/morley-metadata.git
+    commit: 5a54cc98931327f6f110e3a34f6f23176c064396
+- completed:
+    subdir: code/morley-metadata-test
+    name: morley-metadata-test
+    version: '0'
+    git: https://gitlab.com/morley-framework/morley-metadata.git
+    pantry-tree:
+      size: 600
+      sha256: 15de1bae7700e766e9bc60d2e6beefa901a9afeec0fb661609c0b88e129d924d
+    commit: 5a54cc98931327f6f110e3a34f6f23176c064396
+  original:
+    subdir: code/morley-metadata-test
+    git: https://gitlab.com/morley-framework/morley-metadata.git
+    commit: 5a54cc98931327f6f110e3a34f6f23176c064396
+- completed:
     name: base-noprelude
     version: 4.14.3.0
     git: https://github.com/serokell/base-noprelude.git

--- a/test/Test/Indigo/Contracts/HomebaseLite/Metadata/Data.hs
+++ b/test/Test/Indigo/Contracts/HomebaseLite/Metadata/Data.hs
@@ -1,0 +1,56 @@
+-- SPDX-FileCopyrightText: 2022 Tezos Commons
+-- SPDX-License-Identifier: LicenseRef-MIT-TC
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Indigo.Contracts.HomebaseLite.Metadata.Data
+  ( test_metadata_simple
+  ) where
+
+import Fmt (Buildable(..), pretty)
+import Test.Tasty (TestTree)
+
+import Lorentz (errorTagToMText, toVal)
+import Lorentz.Contracts.Spec.TZIP16Interface
+import Morley.Micheline (toExpression)
+import Test.Cleveland
+import Test.Morley.Metadata
+
+import Test.Indigo.Contracts.HomebaseLite.Utils
+
+test_metadata_simple :: TestTree
+test_metadata_simple =
+  testScenario "simple metadata fields are correct" $ scenario do
+    (_, contract) <- deployContract
+    meta <- getMetadata contract
+    evalRight pretty (getName meta) @@== Just "Homebase-Lite"
+    evalRight pretty (getDescription meta) @@== Just "Offchain, decentralized voting system."
+    evalRight pretty (getLicense meta) @@== Just (License "MIT" Nothing)
+    evalRight pretty (getHomepage meta) @@== Just "https://github.com/tezos-commons/homebase-lite"
+    declaredErrors <- evalRight pretty $ getErrors meta
+    for_ knownErrors \err ->
+      assert (hasError err declaredErrors) $ pretty err <> " defined in errors"
+  where
+    knownErrors =
+      [ LabelEx #senderIsNotAdmin_
+      , LabelEx #senderIsNotAdminCandidate
+      , LabelEx #senderIsNotMaintainer
+      , LabelEx #notEnoughTokens
+      , LabelEx #duplicateProposal
+      , LabelEx #emptyChoices
+      , LabelEx #noFA2Contract
+      , LabelEx #noSuchProposal
+      , LabelEx #noSuchChoice
+      , LabelEx #alreadyVoted
+      , LabelEx #proposalNotYetActive
+      , LabelEx #proposalExpired
+      ]
+    hasError :: LabelEx -> [Error] -> Bool
+    hasError k = isJust . find (errHasKey k)
+    errHasKey :: LabelEx -> Error -> Bool
+    errHasKey (LabelEx k) (EStatic StaticError{..}) =
+      seError == toExpression (toVal (errorTagToMText k))
+    errHasKey _ _ = False
+
+instance Buildable License where
+  build = show

--- a/test/Test/Indigo/Contracts/HomebaseLite/Metadata/Views.hs
+++ b/test/Test/Indigo/Contracts/HomebaseLite/Metadata/Views.hs
@@ -1,0 +1,53 @@
+-- SPDX-FileCopyrightText: 2022 Tezos Commons
+-- SPDX-License-Identifier: LicenseRef-MIT-TC
+
+module Test.Indigo.Contracts.HomebaseLite.Metadata.Views
+  ( test_currentConfig
+  , test_proposalInfo
+  ) where
+
+import Data.Text (isInfixOf)
+import Test.Tasty (TestTree)
+
+import Morley.Metadata
+import Morley.Util.Named
+import Test.Cleveland
+import Test.Cleveland.Internal.Exceptions (WithCallStack(..))
+import Test.Cleveland.Internal.Pure (TestError(CustomTestError))
+import Test.Morley.Metadata
+
+import Indigo.Contracts.HomebaseLite
+import Indigo.Contracts.HomebaseLite.Types
+import Test.Indigo.Contracts.HomebaseLite.AsRPC
+import Test.Indigo.Contracts.HomebaseLite.Utils
+
+test_currentConfig :: TestTree
+test_currentConfig =
+  testScenarioOnEmulator "currentConfig view works" $ scenarioEmulated do
+    (admin, contract) <- deployContract
+    callOffChainView contract "currentConfig" NoParam
+      @@== sConfiguration (defaultStorage admin Nothing)
+
+test_proposalInfo :: TestTree
+test_proposalInfo =
+  testScenarioOnEmulator "proposalInfo view works" $ scenarioEmulated do
+    (holder, _, contract) <- deployWithFA2
+    let uri = #proposal_uri :! URI "ipfs://proposal"
+        choices = ["Zero", "One", "Two", "Three"]
+    withSender holder do
+      call contract (Call @"Propose") (uri, #choices :! choices)
+    storage <- getStorage contract
+    let proposals = sProposalsRPC storage
+    proposal <- getBigMapValue proposals uri
+    callOffChainView contract "proposalInfo" (ViewParam uri)
+      @@== proposal
+    res <- attempt $
+      callOffChainView @ProposalInfo
+        contract "proposalInfo" (ViewParam $ #proposal_uri :! URI "ipfs://nonexistent")
+    case res of
+      Left (WithCallStack _ err) -> case fromException err of
+        Just (CustomTestError txt)
+          | "Reached FAILWITH instruction with \"NoSuchProposal\"" `isInfixOf` txt -> pass
+        _ -> failure $
+          "Expected a noSuchProposal error, but got " <> fromString (displayException err)
+      Right _ -> failure "Expected a noSuchProposal error, but the call succeeded"

--- a/test/Test/Indigo/Contracts/HomebaseLite/PropertyTests.hs
+++ b/test/Test/Indigo/Contracts/HomebaseLite/PropertyTests.hs
@@ -44,10 +44,10 @@ genericScenario tokenCount expectation f = scenarioEmulated do
   let stor = FA2.mkStorage meta [((holder, FA2.TokenId 0), tokenCount)] []
       meta = FA2.mkTokenMetadata "g" "governance" "0"
   fa2 <- originateSimple "FA2" stor (FA2.fa2Contract def)
-  (admin, contract) <- deployContractWithConf FA2Config
+  (admin, contract) <- deployContractWithConf (Just FA2Config
     { fa2Addr = toAddress fa2
     , fa2TokenId = TokenId 0
-    } id
+    }) id
   expectation contract $ f holder admin contract
 
 -- | This checks some invariants on the primary workflow:

--- a/test/Test/Indigo/Contracts/HomebaseLite/Utils.hs
+++ b/test/Test/Indigo/Contracts/HomebaseLite/Utils.hs
@@ -2,18 +2,27 @@
 -- SPDX-License-Identifier: LicenseRef-MIT-TC
 
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE OverloadedLists #-}
 
 module Test.Indigo.Contracts.HomebaseLite.Utils
   ( deployContract
   , deployContract'
   , deployContractWithConf
+  , defaultStorage
+  , deployWithFA2
+  , LabelEx(..)
   ) where
 
-import Lorentz (defaultContract)
+import Lorentz (CustomError, IsError, MText, MustHaveErrorArg, toAddress)
 
+import Data.Default (def)
 import Fmt (Buildable(..))
+import GHC.TypeLits (symbolVal)
 
+import qualified Indigo.Contracts.FA2Sample as FA2
+import qualified Lorentz.Contracts.Spec.FA2Interface as FA2
 import Morley.Tezos.Address
+import Morley.Util.Label
 import Morley.Util.Named (pattern (:!))
 import Test.Cleveland
 
@@ -31,33 +40,67 @@ deriving newtype instance Num Seconds
 deployContract
   :: MonadCleveland caps m
   => m (Address, ContractHandle Parameter Storage ())
-deployContract = deployContractWithConf FA2Config
-  { fa2Addr = [ta|KT1AbgvM5D1wAVZbsB3WTCB54E94p2hn1Rb9|]
-  , fa2TokenId = TokenId 0
-  } id
+deployContract = deployContract' id
 
 deployContract'
   :: MonadCleveland caps m
   => (Storage -> Storage)
   -> m (Address, ContractHandle Parameter Storage ())
-deployContract' = deployContractWithConf FA2Config
-  { fa2Addr = [ta|KT1AbgvM5D1wAVZbsB3WTCB54E94p2hn1Rb9|]
-  , fa2TokenId = TokenId 0
-  }
+deployContract' = deployContractWithConf Nothing
 
 deployContractWithConf
   :: MonadCleveland caps m
-  => FA2Config
+  => Maybe FA2Config
   -> (Storage -> Storage)
   -> m (Address, ContractHandle Parameter Storage ())
 deployContractWithConf fa2conf modStor = do
   admin <- newAddress "admin"
-  let stor = modStor $ initialStorage
-        (#admin :! admin)
-        (#expireTime :! 3600)
-        (#voteDelay :! 600)
-        (#quorumThreshold :! 1)
-        (#minimumBalance :! 1)
-        (#fa2config :! fa2conf)
-  contract <- originateSimple "HomebaseLite" stor $ defaultContract homebaseLiteCode
+  let stor = modStor $ defaultStorage admin fa2conf
+  contract <- originateSimple "HomebaseLite" stor lorentzContract
   pure (admin, contract)
+
+defaultStorage :: Address -> Maybe FA2Config -> Storage
+defaultStorage admin fa2conf = initialStorage
+  (#admin :! admin)
+  (#expireTime :! 3600)
+  (#voteDelay :! 600)
+  (#quorumThreshold :! 1)
+  (#minimumBalance :! 1)
+  (#fa2config :! fromMaybe defaultFa2conf fa2conf)
+  (#metadataConfig :! def)
+  where
+    defaultFa2conf = FA2Config
+      { fa2Addr = [ta|KT1AbgvM5D1wAVZbsB3WTCB54E94p2hn1Rb9|]
+      , fa2TokenId = TokenId 0
+      }
+
+deriving stock instance Eq Seconds
+deriving stock instance Eq Configuration
+
+instance Buildable Configuration where
+  build = show
+
+deriving stock instance Eq ProposalInfo
+
+instance Buildable ProposalInfo where
+  build = show
+
+deployWithFA2 :: MonadCleveland caps m => m (Address, Address, ContractHandle Parameter Storage ())
+deployWithFA2 = do
+  holder <- newAddress "holder"
+  let stor = FA2.mkStorage meta [((holder, FA2.TokenId 0), 100)] []
+      meta = FA2.mkTokenMetadata "g" "governance" "0"
+  fa2 <- originateSimple "FA2" stor (FA2.fa2Contract def)
+  (admin, contract) <- deployContractWithConf (Just FA2Config
+    { fa2Addr = toAddress fa2
+    , fa2TokenId = TokenId 0
+    }) id
+  pure (holder, admin, contract)
+
+data LabelEx
+  = forall tag.
+    (IsError (CustomError tag), MustHaveErrorArg tag MText)
+  => LabelEx (Label tag)
+
+instance Buildable LabelEx where
+  build (LabelEx (Label :: Label tag)) = fromString $ symbolVal (Proxy @tag)


### PR DESCRIPTION
~~Note: based off #20 due to readme changes.~~

I need a bit of advice here. The tests from `morley-metadata-test` all pass, and as far as I understand the spec, the contract is apparently following it. However, when I tried testing a [testnet-deployed contract with TZComet](https://tzcomet.io/#/explorer%3Fexplorer-input%3DKT1VvnQFn9v3oHA7JLTdDZD6hdAx3T4TnUA2), it says `Failure: Contract has no valid %metadata big-map!`, despite `(big_map %metadata string bytes)` being right there in the log. ~~It seems something is bugged here, but I can't say what exactly.~~

Apparently it's a bug in TZComet, it doesn't understand the shortened `pair` syntax in storage type definitions. I've created an issue there.

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

Problem: This contract would benefit from TZIP-16 support

Solution: Add TZIP-16 metadata. Add two off-chain views:

- Get current contract configuration
- Get ProposalInfo for a given proposal URI

NB: with latest spec tweaks, the third view listed in the issue doesn't really make much sense.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->
Resolves #16

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)


- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
