### PR TITLE
[Chore] Update version number for 0.1 release

### DIFF
--- a/homebase-lite.cabal
+++ b/homebase-lite.cabal
@@ -5,12 +5,12 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           homebase-lite
-version:        0
+version:        0.1.0
 description:    Tezos smart contract for a decentralized voting system, based on “snapshots” of the blockchain
 homepage:       https://github.com/tezos-commons/homebase-lite#readme
 bug-reports:    https://github.com/tezos-commons/homebase-lite/issues
 author:         Serokell <hi@serokell.io>
-maintainer:     Maintainers of this package <we-maintain@this.package>
+maintainer:     Serokell <hi@serokell.io>
 copyright:      2022 Tezos Commons
 license:        MIT
 license-file:   LICENSE

--- a/package.yaml
+++ b/package.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: LicenseRef-MIT-TC
 
 name: homebase-lite
-version: 0
+version: 0.1.0
 author: Serokell <hi@serokell.io>
 github: tezos-commons/homebase-lite
 
@@ -13,7 +13,7 @@ description:
 copyright: 2022 Tezos Commons
 license-file: LICENSE
 
-maintainer: Maintainers of this package <we-maintain@this.package>
+maintainer: Serokell <hi@serokell.io>
 
 # We enable all extensions that we consider harmless by default.
 default-extensions:


### PR DESCRIPTION
## Description

Problem: the codebase is mature enough to justify a first "0.1"
release, but the package metadata still has "0" as its version.

Solution: bump the version number in the package.
Additionally, update the "maintainer" field as well.

## Related issue(s)

None

## :white_check_mark: Checklist for your Pull Request

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)


- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
